### PR TITLE
Add ExportData.io to Twitter OSINT list

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Slack Team: https://openosint.slack.com
 [Bioischanged](http://bioischanged.com/)<br>
 [Crate](https://getcrate.co/)<br>
 [doesfollow](https://doesfollow.com/)<br>
+[ExportData](https://www.exportdata.io/)<br>
 [Fake Follower Check](https://fakers.statuspeople.com/)<br>
 [First Tweet](http://ctrlq.org/first)<br>
 [Foller.me](http://foller.me/)<br>


### PR DESCRIPTION
It allows downloading followers, followings, historical tweets from 2006 and historical trends.